### PR TITLE
Review / Simplify permissions

### DIFF
--- a/adminsettings.php
+++ b/adminsettings.php
@@ -26,108 +26,108 @@ require_once(__DIR__ . '/../../config.php');
 require_once($CFG->libdir . '/adminlib.php');
 require_login();
 
-if (has_capability('block/qrcode:changelogo', context_system::instance())) {
+require_capability('moodle/site:config', context_system::instance());
 
-    admin_externalpage_setup('block_qrcode');
-    echo $OUTPUT->header();
-    echo $OUTPUT->heading(get_string('settings', 'block_qrcode'));
+admin_externalpage_setup('block_qrcode');
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('settings', 'block_qrcode'));
 
-    $mform = new block_qrcode\admin_form();
+$mform = new block_qrcode\admin_form();
 
-    // Form is submitted.
-    if ($data = $mform->get_data()) {
-        // Set logo config.
-        $oldvalue = get_config('block_qrcode', 'use_logo');
-        $oldvalue = ($oldvalue === false) ? null : $oldvalue;
-        $value = $data->use_logo;
+// Form is submitted.
+if ($data = $mform->get_data()) {
+    // Set logo config.
+    $oldvalue = get_config('block_qrcode', 'use_logo');
+    $oldvalue = ($oldvalue === false) ? null : $oldvalue;
+    $value = $data->use_logo;
 
-        if ($oldvalue !== $value) {
-            // Store change.
-            set_config('use_logo', $value, 'block_qrcode');
+    if ($oldvalue !== $value) {
+        // Store change.
+        set_config('use_logo', $value, 'block_qrcode');
+    }
+
+
+    $contextid = context_system::instance()->id;
+
+    // Save png logo.
+    if ($draftitemid = file_get_submitted_draft_itemid('logo_png')) {
+        file_save_draft_area_files($draftitemid, $contextid, 'block_qrcode', 'logo_png', 0,
+            array('subdirs' => false, 'maxfiles' => 1));
+
+        $fs = get_file_storage();
+        $files = $fs->get_area_files($contextid, 'block_qrcode', 'logo_png', 0, 'sortorder,filepath,filename', false);
+
+        $filepath = '';
+        if ($files) {
+            /** @var stored_file $file */
+            $file = reset($files);
+            $filepath = $file->get_filepath() . $file->get_filename();
         }
+        set_config('logofile_png', $filepath, 'block_qrcode');
 
+        // Delete old QR codes.
+        $pattern = $CFG->localcachedir . '/block_qrcode/course-*-*-1.png';
 
-        $contextid = context_system::instance()->id;
-
-        // Save png logo.
-        if ($draftitemid = file_get_submitted_draft_itemid('logo_png')) {
-            file_save_draft_area_files($draftitemid, $contextid, 'block_qrcode', 'logo_png', 0,
-                array('subdirs' => false, 'maxfiles' => 1));
-
-            $fs = get_file_storage();
-            $files = $fs->get_area_files($contextid, 'block_qrcode', 'logo_png', 0, 'sortorder,filepath,filename', false);
-
-            $filepath = '';
-            if ($files) {
-                /** @var stored_file $file */
-                $file = reset($files);
-                $filepath = $file->get_filepath() . $file->get_filename();
-            }
-            set_config('logofile_png', $filepath, 'block_qrcode');
-
-            // Delete old QR codes.
-            $pattern = $CFG->localcachedir . '/block_qrcode/course-*-*-1.png';
-
-            foreach (glob($pattern) as $filename) {
-                unlink($filename);
-            }
-
-        }
-
-        // Save svg logo.
-        if ($draftitemid = file_get_submitted_draft_itemid('logo_svg')) {
-            file_save_draft_area_files(
-                $draftitemid,
-                $contextid,
-                'block_qrcode',
-                'logo_svg',
-                0,
-                array('subdirs' => false, 'maxfiles' => 1));
-
-            $fs = get_file_storage();
-            $files = $fs->get_area_files($contextid, 'block_qrcode', 'logo_svg', 0, 'sortorder,filepath,filename', false);
-
-            $filepath = '';
-            if ($files) {
-                /** @var stored_file $file */
-                $file = reset($files);
-                $filepath = $file->get_filepath() . $file->get_filename();
-            }
-            set_config('logofile_svg', $filepath, 'block_qrcode');
-
-            // Delete old QR codes.
-            $pattern = $CFG->localcachedir . '/block_qrcode/course-*-*-1.svg';
-
-            foreach (glob($pattern) as $filename) {
-                unlink($filename);
-            }
+        foreach (glob($pattern) as $filename) {
+            unlink($filename);
         }
 
     }
 
-    if (empty($entry->id)) {
-        $entry = new stdClass;
-        $entry->id = 0;
+    // Save svg logo.
+    if ($draftitemid = file_get_submitted_draft_itemid('logo_svg')) {
+        file_save_draft_area_files(
+            $draftitemid,
+            $contextid,
+            'block_qrcode',
+            'logo_svg',
+            0,
+            array('subdirs' => false, 'maxfiles' => 1));
+
+        $fs = get_file_storage();
+        $files = $fs->get_area_files($contextid, 'block_qrcode', 'logo_svg', 0, 'sortorder,filepath,filename', false);
+
+        $filepath = '';
+        if ($files) {
+            /** @var stored_file $file */
+            $file = reset($files);
+            $filepath = $file->get_filepath() . $file->get_filename();
+        }
+        set_config('logofile_svg', $filepath, 'block_qrcode');
+
+        // Delete old QR codes.
+        $pattern = $CFG->localcachedir . '/block_qrcode/course-*-*-1.svg';
+
+        foreach (glob($pattern) as $filename) {
+            unlink($filename);
+        }
     }
 
-    // Load existing files in draft area.
-    $draftitemid = file_get_submitted_draft_itemid('logo_png');
-    file_prepare_draft_area($draftitemid, context_system::instance()->id, 'block_qrcode', 'logo_png',
-        $entry->id, array('subdirs' => 0, 'maxbytes' => 0, 'maxfiles' => 1));
-
-    $entry->logo_png = $draftitemid;
-
-    $draftitemid = file_get_submitted_draft_itemid('logo_svg');
-    file_prepare_draft_area($draftitemid, context_system::instance()->id, 'block_qrcode', 'logo_svg',
-        $entry->id, array('subdirs' => 0, 'maxbytes' => 1000000, 'maxfiles' => 1));
-
-    $entry->logo_svg = $draftitemid;
-
-    $entry->use_logo = get_config('block_qrcode', 'use_logo');
-
-    $mform->set_data($entry);
-    $mform->display();
-
-
-    echo $OUTPUT->footer();
 }
+
+if (empty($entry->id)) {
+    $entry = new stdClass;
+    $entry->id = 0;
+}
+
+// Load existing files in draft area.
+$draftitemid = file_get_submitted_draft_itemid('logo_png');
+file_prepare_draft_area($draftitemid, context_system::instance()->id, 'block_qrcode', 'logo_png',
+    $entry->id, array('subdirs' => 0, 'maxbytes' => 0, 'maxfiles' => 1));
+
+$entry->logo_png = $draftitemid;
+
+$draftitemid = file_get_submitted_draft_itemid('logo_svg');
+file_prepare_draft_area($draftitemid, context_system::instance()->id, 'block_qrcode', 'logo_svg',
+    $entry->id, array('subdirs' => 0, 'maxbytes' => 1000000, 'maxfiles' => 1));
+
+$entry->logo_svg = $draftitemid;
+
+$entry->use_logo = get_config('block_qrcode', 'use_logo');
+
+$mform->set_data($entry);
+$mform->display();
+
+
+echo $OUTPUT->footer();
+

--- a/db/access.php
+++ b/db/access.php
@@ -38,22 +38,9 @@ $capabilities = array(
         'captype' => 'read',
         'contextlevel' => CONTEXT_COURSE,
         'archetypes' => array(
-            'student' => CAP_PROHIBIT,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
             'coursecreator' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        )
-    ),
-
-    'block/qrcode:changelogo' => array(
-        'captype' => 'write',
-        'contextlevel' => CONTEXT_SYSTEM,
-        'archetypes' => array(
-            'student' => CAP_PROHIBIT,
-            'teacher' => CAP_PROHIBIT,
-            'editingteacher' => CAP_PROHIBIT,
-            'coursecreator' => CAP_PROHIBIT,
             'manager' => CAP_ALLOW
         )
     ),

--- a/lang/en/block_qrcode.php
+++ b/lang/en/block_qrcode.php
@@ -24,7 +24,7 @@
 
 $string['pluginname'] = 'QR code';
 $string['qrcode:addinstance'] = 'Add a new QR code block';
-$string['qrcode:seebutton'] = 'Show Download button';
+$string['qrcode:download'] = 'Show Download button';
 $string['filename'] = 'course';
 $string['cachedef_qrcodes'] = 'Cache for the QR codes';
 $string['img_tag_alt'] = 'QR code';

--- a/styles.css
+++ b/styles.css
@@ -13,3 +13,7 @@
 .block_qrcode #fitem_id_submitbutton .fsubmit {
     margin: 0px;
 }
+
+.block_qrcode .mform {
+    margin: 0px 10px;
+}


### PR DESCRIPTION
`if (has_capability(...` can (sometimes, e.g. here) be exchanged by `require_capability`, resulting in much cleaner code structure (cf. `adminsettings.php`).

The capability `block/qrcode:changelogo` is not required. 

The capability `block/qrcode:seebutton` was renamed at some point, rendering the language strings inconsistent. Fixed.

It is not required to explicitly disallow someone from doing something. The default is always to not have a capability. Deleted all `CAP_PROHIBIT` configurations.