### PR TITLE
Clear cache after changing wwwroot

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Functions for the QR code block.
+ *
+ * @package block_qrcode
+ * @copyright 2026 L. Herfeldt
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Clears cached QR code images when relevant global settings are changed.
+ *
+ * This is used after changing the custom wwwroot, because existing cached
+ * QR image files may still contain the old URL.
+ */
+function block_qrcode_clear_cache(): void {
+    $cachedir = make_localcache_directory('block_qrcode', false);
+
+    if ($cachedir !== false && is_dir($cachedir)) {
+        remove_dir($cachedir, true);
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -22,8 +22,6 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Clears cached QR code images when relevant global settings are changed.
  *

--- a/settings.php
+++ b/settings.php
@@ -23,15 +23,20 @@
  */
 
 defined('MOODLE_INTERNAL') || die;
+require_once($CFG->dirroot . '/blocks/qrcode/lib.php');
 
 if ($ADMIN->fulltree) {
-    $settings->add(new admin_setting_configtext(
+    $setting = new admin_setting_configtext(
         'block_qrcode/custom_wwwroot',
         new lang_string('customwwwroot', 'block_qrcode'),
         new lang_string('customwwwroot_desc', 'block_qrcode', $CFG->wwwroot),
         '',
-        PARAM_URL,
-    ));
+        PARAM_URL
+    );
+
+    $setting->set_updatedcallback('block_qrcode_clear_cache');
+
+    $settings->add($setting);
 
     $settings->add(new admin_setting_configcheckbox(
         'block_qrcode/use_logo',


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

This PR fixes an issue where QR codes were not updated after changing the custom wwwroot setting.

Before this change, Moodle could keep using old cached QR code images, so the QR codes still pointed to the previous URL. This was not how it should be because the setting had changed, but the generated QR codes did not. Now, when the custom wwwroot setting is changed, the QR code cache is cleared. The next time a QR code is shown, it is generated again with the new URL.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [x] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [x] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [x] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #[66](https://github.com/learnweb/moodle-block_qrcode/issues/66)

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Any other relevant information.

---